### PR TITLE
do not install gcc5 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ addons:
         sources:
             - ubuntu-toolchain-r-test
         packages:
-            - gcc-5
-            - g++-5
             - lcov
-
 
 branches:
   only:


### PR DESCRIPTION
The default gcc 4.8 works fine and is used since the last commit anyway.