### PR TITLE
Fixed cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   else()
     target_link_libraries(coverage_config INTERFACE --coverage)
   endif()
-endif(CODE_COVERAGE)
+endif(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 
 
 add_subdirectory(src)


### PR DESCRIPTION
A logical block opening on the line CMakeLists.txt:15 (`if`) closes on the line CMakeLists.txt:27 (`endif`) with mis-matching arguments.